### PR TITLE
Fixes for MathJax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,7 +46,7 @@
 
 {% if page.mathjax %}
 <!--Load Mathjax-->
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         <script>
         MathJax.Hub.Config({
             config: ["MMLorHTML.js"],


### PR DESCRIPTION
MathJax CDN is changed to CDNjs.